### PR TITLE
chore: rename package to test-registro-ventas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "test-registro-ventas",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-react-typescript-starter",
+      "name": "test-registro-ventas",
       "version": "0.0.0",
       "dependencies": {
         "lucide-react": "^0.344.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "test-registro-ventas",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- rename project to `test-registro-ventas`
- sync lockfile with new package name

## Testing
- `npm run lint` *(fails: err defined but never used; unexpected any)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68917657474c8332b498f98efa9e93da